### PR TITLE
Revert version and fix Debian dist errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM inquicker/iqapp-base:2.5.1
+FROM inquicker/iqapp-base:2.3.3
+
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 
 RUN apt-get update && \
   apt-get upgrade -y && \


### PR DESCRIPTION
InQuicker still runs on 2.3.x, so we should keep our dev environment the same.

This was discovered when trying to run BerylSyncJobs (an IQApp job) locally, and `net-ssh` was throwing errors because OpenSSL was at a newer version locally, and had deprecated some functionality.

This PR also includes a line to fix fetching the debian dists, which is part of the build process. Fix came from: https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease

